### PR TITLE
Open schedule patches

### DIFF
--- a/app/presenters/appointments_presenter.rb
+++ b/app/presenters/appointments_presenter.rb
@@ -5,22 +5,20 @@ class AppointmentsPresenter
 
   def recent_appointments
     @recent_appointments ||= \
-      user_massages
+      user
+      .massages
       .scheduled_massages
       .where('timetable > ?', interval_to_be_considered_recent)
+      .order(:timetable)
   end
 
   def past_appointments
-    @past_appointments ||= user_massages.past_massages
+    user.massages.past_massages.order(timetable: :desc)
   end
 
   private
 
   attr_reader :user
-
-  def user_massages
-    @user_massages ||= user.massages.order(timetable: :desc)
-  end
 
   def interval_to_be_considered_recent
     Time.zone.now - ScheduleSettings.massage_duration

--- a/app/presenters/schedule/timetables_presenter.rb
+++ b/app/presenters/schedule/timetables_presenter.rb
@@ -53,7 +53,8 @@ module Schedule
     end
 
     def build_end_time(request_time)
-      request_time.at_beginning_of_day + (ScheduleSettings.scheduling_window_days - 1).day
+      delta_days = (ScheduleSettings.scheduling_window_days - 1).day
+      request_time.at_end_of_day + delta_days
     end
   end
 end

--- a/app/validators/timetable_validator.rb
+++ b/app/validators/timetable_validator.rb
@@ -12,7 +12,12 @@ class TimetableValidator < ActiveModel::EachValidator
   end
 
   def schedule_table(request_time)
-    end_time = request_time + (ScheduleSettings.scheduling_window_days - 1).day
+    end_time = build_end_time(request_time)
     Schedule::TableGenerator.new.schedule_table(request_time, end_time)
+  end
+
+  def build_end_time(request_time)
+    delta_days = (ScheduleSettings.scheduling_window_days - 1).day
+    request_time.at_end_of_day + delta_days
   end
 end

--- a/app/views/panel/appointments/_schedule.html.erb
+++ b/app/views/panel/appointments/_schedule.html.erb
@@ -1,12 +1,14 @@
 <ul class="ls-tabs-nav">
-  <% @available_timetables.each do |massage_date| %>
-    <li><a data-ls-module="tabs" href="#day-<%= massage_date[:date].to_s %>"> <%= l(massage_date[:date], format: '%A | %d/%m/%Y') %></a></li>
+  <% @available_timetables.each.with_index do |massage_date, index| %>
+    <li class="<%= if(index == 0) then 'ls-active' end %>">
+      <a data-ls-module="tabs" href="#day-<%= massage_date[:date].to_s %>"> <%= l(massage_date[:date], format: '%A | %d/%m/%Y') %></a>
+    </li>
   <% end %>
 </ul>
 
 <div class="ls-tabs-container">
-  <% @available_timetables.each do |massage_date| %>
-    <div id="day-<%= massage_date[:date].to_s %>" class="ls-tab-content" >
+  <% @available_timetables.each.with_index do |massage_date, index| %>
+    <div id="day-<%= massage_date[:date].to_s %>" class="ls-tab-content <%= if(index == 0) then 'ls-active' end %>" >
 
       <% massage_date[:periods].each do |massage_period| %>
         <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6">

--- a/config/schedule_settings.yml
+++ b/config/schedule_settings.yml
@@ -4,7 +4,7 @@ development: &default
   massage_end: '18:00'
   location: Sala Quick Massage
   pauses: [['10:30', '10:45'], ['12:00', '13:00'], ['16:30', '16:45']]
-  scheduling_window_days: 5
+  scheduling_window_days: 7
   scheduled_limit_per_week: 1
   scheduled_limit_total: 2
   massage_days: [ Monday, Wednesday, Friday ]


### PR DESCRIPTION
- Alterada ordem das massagens agendadas para exibir os agendamentos mais próximos primeiro
- Corrigido bug em que a configuração de dias da janela de agendamento estava com 1 dia de defasagem
- Alterada tela de agendamento para que a primeira aba já carregue ativa